### PR TITLE
support classpath: for loading PEMCFG resources

### DIFF
--- a/src/main/java/de/dentrassi/crypto/pem/PemUtils.java
+++ b/src/main/java/de/dentrassi/crypto/pem/PemUtils.java
@@ -29,13 +29,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import de.dentrassi.crypto.pem.AbstractPemKeyStore.Entry;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+
+import de.dentrassi.crypto.pem.AbstractPemKeyStore.Entry;
 
 public class PemUtils {
 
@@ -77,7 +78,7 @@ public class PemUtils {
         if (uri.startsWith("classpath:")) {
             return Thread.currentThread().getContextClassLoader().getResourceAsStream(uri.substring(10));
         } else {
-            return new FileInputStream(uri);
+            return new FileInputStream(uri.startsWith("file://") ? uri.substring(7) : uri);
         }
     }
 

--- a/src/main/java/de/dentrassi/crypto/pem/PemUtils.java
+++ b/src/main/java/de/dentrassi/crypto/pem/PemUtils.java
@@ -12,7 +12,6 @@
 package de.dentrassi.crypto.pem;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,14 +29,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import de.dentrassi.crypto.pem.AbstractPemKeyStore.Entry;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-
-import de.dentrassi.crypto.pem.AbstractPemKeyStore.Entry;
 
 public class PemUtils {
 
@@ -65,7 +63,7 @@ public class PemUtils {
 
         for (final String key : p.stringPropertyNames()) {
             if (key.startsWith(SOURCE_PREFIX)) {
-                try (FileInputStream source = new FileInputStream(new File(p.getProperty(key)))) {
+                try (InputStream source = openResource(p.getProperty(key))) {
                     loadFrom(result, alias, true, source);
                 }
             }
@@ -73,6 +71,14 @@ public class PemUtils {
 
         return result;
 
+    }
+
+    private static InputStream openResource(final String uri) throws IOException {
+        if (uri.startsWith("classpath:")) {
+            return Thread.currentThread().getContextClassLoader().getResourceAsStream(uri.substring(10));
+        } else {
+            return new FileInputStream(uri);
+        }
     }
 
     private static void loadFrom(final Map<String, Entry> result, final String alias, final boolean chained,

--- a/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
+++ b/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc and others.
+ * Copyright (c) 2020 CarePay International
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
+++ b/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Barry Lagerweij - Added classpath prefix support
+ *******************************************************************************/
+
 package de.dentrassi.crypto.pem;
 
 import java.io.IOException;
@@ -13,6 +24,14 @@ class PemUtilsTest {
     @Test
     void loadFromConfigurationClasspath() throws CertificateException, IOException {
         Map<String, AbstractPemKeyStore.Entry> map = PemUtils.loadFromConfiguration(getClass().getResourceAsStream("/classpath_tls.properties"));
+        AbstractPemKeyStore.Entry entry = map.get("keycert");
+        assertThat(entry.getKey()).isNotNull();
+        assertThat(entry.getCertificate()).isNotNull();
+    }
+
+    @Test
+    void loadFromConfigurationFile() throws CertificateException, IOException {
+        Map<String, AbstractPemKeyStore.Entry> map = PemUtils.loadFromConfiguration(getClass().getResourceAsStream("/file_tls.properties"));
         AbstractPemKeyStore.Entry entry = map.get("keycert");
         assertThat(entry.getKey()).isNotNull();
         assertThat(entry.getCertificate()).isNotNull();

--- a/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
+++ b/src/test/java/de/dentrassi/crypto/pem/PemUtilsTest.java
@@ -1,0 +1,20 @@
+package de.dentrassi.crypto.pem;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PemUtilsTest {
+
+    @Test
+    void loadFromConfigurationClasspath() throws CertificateException, IOException {
+        Map<String, AbstractPemKeyStore.Entry> map = PemUtils.loadFromConfiguration(getClass().getResourceAsStream("/classpath_tls.properties"));
+        AbstractPemKeyStore.Entry entry = map.get("keycert");
+        assertThat(entry.getKey()).isNotNull();
+        assertThat(entry.getCertificate()).isNotNull();
+    }
+}

--- a/src/test/resources/classpath_tls.properties
+++ b/src/test/resources/classpath_tls.properties
@@ -1,0 +1,3 @@
+alias=keycert
+source.key-alias=classpath:tls.key
+source.cert-alias=classpath:tls.crt

--- a/src/test/resources/file_tls.properties
+++ b/src/test/resources/file_tls.properties
@@ -1,0 +1,3 @@
+alias=keycert
+source.key-alias=file://./src/test/resources/tls.key
+source.cert-alias=file://./src/test/resources/tls.crt

--- a/src/test/resources/file_tls.properties
+++ b/src/test/resources/file_tls.properties
@@ -1,3 +1,3 @@
 alias=keycert
-source.key-alias=file://./src/test/resources/tls.key
-source.cert-alias=file://./src/test/resources/tls.crt
+source.key-alias=file://src/test/resources/tls.key
+source.cert-alias=file://src/test/resources/tls.crt


### PR DESCRIPTION
Added support for loading PEMCFG resources from classpath.
For example:
alias=keycert
source.key-alias=classpath:tls.key
source.cert-alias=classpath:tls.crt